### PR TITLE
Remove return for failed Hiera datafile download

### DIFF
--- a/functions/puppetFunctions.sh
+++ b/functions/puppetFunctions.sh
@@ -97,7 +97,7 @@ function getHieraDataFiles {
         ln "${file}" "${filearray[1]}"
       else
         echo "Failed to download datafile: ${datafile}" >&2
-        return 3
+        #return 3
       fi
     else
       echo "Incorrect format for datafile: ${datafile}" >&2


### PR DESCRIPTION
Since Hiera datafiles themselves don't cause errors if they don't
exist, it would make sense the some files might not be accessible
in all cases, so we shouldn't abort if a file can't be downloaded.
This is especially useful if local files were included that can be
reached when used from environments such as Vagrant, but not AWS,
thus allowing for local overrides.
